### PR TITLE
Using multistage build to build bioperl from master using dzil

### DIFF
--- a/bioperl/Dockerfile
+++ b/bioperl/Dockerfile
@@ -13,13 +13,20 @@ LABEL maintainer="Hilmar Lapp <hlapp@drycafe.net>"
 # in the builder stage
 WORKDIR /bioperl
 
+# Prevent error messages from debconf about non-interactive frontend
+ARG TERM=linux
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install software needed to build BioPerl (not all are required to run it)
-RUN apt-get install --yes wget git && \
-  cpanm -n Dist::Zilla Dist::Zilla::Plugin::Git && \
-  wget --no-check-certificate \
-  -O master.tar.gz \
-  https://github.com/bioperl/bioperl-live/archive/master.tar.gz && \
-  tar xzf master.tar.gz && \
+RUN apt-get update --yes && \
+    apt-get install --yes git
+RUN cpanm -n Dist::Zilla Dist::Zilla::Plugin::Git
+
+# download BioPerl soure, install authordeps, build BioPerl
+RUN \
+  curl -L -s -o - \
+         https://github.com/bioperl/bioperl-live/archive/master.tar.gz | \
+    tar xzf - && \
   cd bioperl-live-master && \
   dzil authordeps | cpanm -n && \
   dzil build --in /bioperl/bioperl-build
@@ -31,7 +38,7 @@ FROM bioperl/bioperl-deps as final
 # Install modules recommended by BioPerl.
 # We can't include Bio::ASN1::EntrezGene here yet, because it declares
 # a dependency on BioPerl, thus pulling in BioPerl first.
-RUN cpanm -n\
+RUN cpanm -n \
   Bio::Phylo
 
 # -------------------------------------------------------------
@@ -41,11 +48,10 @@ RUN cpanm -n\
 # -------------------------------------------------------------
 # Copy the files produced in the previous build stage over to the 
 # final image
-WORKDIR /usr/local/src/bioperl-build
-COPY --from=builder /bioperl/bioperl-build .
+COPY --from=builder /bioperl/bioperl-build /usr/local/src/bioperl-build/
 
 # Install bioperl
-RUN cpanm -n .
+RUN cpanm -n /usr/local/src/bioperl-build
 
 # Install modules recommended by BioPerl that depend on BioPerl.
 # (Don't ask. See above.)

--- a/bioperl/Dockerfile
+++ b/bioperl/Dockerfile
@@ -4,15 +4,34 @@
 ############################################################
 
 # Set the base image to the BioPerl prebuilt prerequisites image
-FROM bioperl/bioperl-deps
+FROM bioperl/bioperl-deps as builder
 
 # File Author / Maintainer
-MAINTAINER Hilmar Lapp <hlapp@drycafe.net>
+LABEL maintainer="Hilmar Lapp <hlapp@drycafe.net>"
+
+# Set the working directory to where we will install bioperl
+# in the builder stage
+WORKDIR /bioperl
+
+# Install software needed to build BioPerl (not all are required to run it)
+RUN apt-get install --yes wget git && \
+  cpanm -n Dist::Zilla Dist::Zilla::Plugin::Git && \
+  wget --no-check-certificate \
+  -O master.tar.gz \
+  https://github.com/bioperl/bioperl-live/archive/master.tar.gz && \
+  tar xzf master.tar.gz && \
+  cd bioperl-live-master && \
+  dzil authordeps | cpanm -n && \
+  dzil build --in /bioperl/bioperl-build
+
+# Set the base image to the BioPerl prebuilt prerequisites image
+# this time for the final image
+FROM bioperl/bioperl-deps as final
 
 # Install modules recommended by BioPerl.
 # We can't include Bio::ASN1::EntrezGene here yet, because it declares
 # a dependency on BioPerl, thus pulling in BioPerl first.
-RUN cpanm \
+RUN cpanm -n\
   Bio::Phylo
 
 # -------------------------------------------------------------
@@ -20,8 +39,13 @@ RUN cpanm \
 #
 # This is the actual installation step of BioPerl itself :-)
 # -------------------------------------------------------------
-RUN cpanm -v \
-  https://github.com/bioperl/bioperl-live/archive/master.tar.gz
+# Copy the files produced in the previous build stage over to the 
+# final image
+WORKDIR /usr/local/src/bioperl-build
+COPY --from=builder /bioperl/bioperl-build .
+
+# Install bioperl
+RUN cpanm -n .
 
 # Install modules recommended by BioPerl that depend on BioPerl.
 # (Don't ask. See above.)


### PR DESCRIPTION
I've made use of multi-stage build functionality (available in docker since version 17.05) to build BioPerl in one stage, and install the built distribution in the final stage, along with all BioPerl dependencies. Dependencies only used during building are not included in the final image.

What I've done may be a bit naive in parts, so if someone who is more seasoned in Docker can take a look at it and clean it up even more, that would be appreciated. As it is, this Works For Me™.